### PR TITLE
docs: fix two day-one onboarding gaps (unrunnable step 3 check, GitHub account ambiguity)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+**Status: draft skeleton — needs review before this is real.**
+
+This applies to teammates and community contributors alike, across GitHub issues/PRs, Slack, and any other space where we work together.
+
+## Our standard
+
+<!-- TODO: a short paragraph — respectful, welcoming, assume good intent. Point to [Culture](culture.md) for the everyday version of this. -->
+
+## When a discussion turns unproductive
+
+<!-- TODO: fill in with the team —
+- Move to a call instead of continuing in text?
+- Give it a cooling-off period?
+- Loop in a manager at what point?
+-->
+
+## Reporting a concern
+
+<!-- TODO:
+- Who do you go to? (manager, specific person, anonymous channel?)
+- What happens after a report — is there a process, a timeline?
+-->
+
+## Community contributor conduct
+
+<!-- TODO: who owns moderating issues/PRs from outside contributors, and what's the escalation path if a contributor is disruptive? -->
+
+## Enforcement
+
+<!-- TODO: consequences for teammates vs. outside contributors, if this needs to be spelled out -->

--- a/culture.md
+++ b/culture.md
@@ -59,6 +59,27 @@ Beyond that, structure your day however works for you. Early bird, night owl, mi
 - **Summarize outcomes.** Decisions from calls go into the relevant issue or PR so nobody has to have been there to stay informed.
 - **Record when practical** so teammates in different schedules can catch up.
 
+## Code Review Culture
+
+<!-- DRAFT skeleton — needs review before this is real. -->
+
+<!-- TODO: turnaround expectations — same no-SLA async norm as everything else, or something firmer? -->
+
+**Giving feedback:**
+
+<!-- TODO:
+- Blocking vs. non-blocking comments — do we mark which is which (e.g. a "nit:" prefix)?
+- Any house convention for phrasing so feedback reads as collaborative, not personal?
+-->
+
+**Receiving feedback:**
+
+<!-- TODO: pushback is normal and welcome — how do disagreements get resolved if reviewer and author don't converge? Third reviewer? Manager? -->
+
+**Who reviews?**
+
+<!-- TODO: day-one.md already flags that requested-vs-assigned reviewers varies by team — does this doc need an org-wide default, or just point there? -->
+
 ## Work, Right, Fast
 
 Our development philosophy follows three stages, in order:
@@ -89,3 +110,21 @@ When in doubt, bias toward action. It's easier to iterate on something that exis
 No question is too basic. We all started somewhere, and asking early often saves everyone time.
 
 **Timebox before asking for help.** If you're stuck, give it 30–60 minutes, then reach out to a teammate or set up a pairing session. A 5-minute conversation can often unblock hours of solo debugging — and that's a win for the whole team.
+
+## When Things Get Difficult
+
+<!-- DRAFT skeleton — needs review before this is real. -->
+
+Our [Code of Conduct](CODE_OF_CONDUCT.md) applies to teammates and community contributors alike.
+
+<!-- TODO: if a GitHub thread or Slack conversation turns unproductive —
+- Move to a call instead of continuing in text?
+- Give it a cooling-off period?
+- Loop in a manager at what point?
+-->
+
+**Reporting a concern:** <!-- TODO: who do you go to, and how? -->
+
+## Data Handling
+
+See [Data Handling](data-handling.md) for where the "open source by default" line sits relative to the data our tools work with — code and discussion are public, but not everything that touches real records is.

--- a/data-handling.md
+++ b/data-handling.md
@@ -1,0 +1,24 @@
+# Data Handling
+
+**Status: draft skeleton — needs review before this is real.**
+
+We're open source by default (see [Culture](culture.md#open-source-by-default)) — our code, issues, and PRs are public. This page is about the line between that and the data our tools work with, which isn't always the same thing.
+
+## What's always fine in a public issue or PR
+
+<!-- TODO: e.g. synthetic/fixture data, code, architecture discussion, bug reports that don't quote real records -->
+
+## What needs care, even though the repo is public
+
+<!-- TODO:
+- Test fixtures — synthetic only, or is sanitized real data ever OK?
+- Screenshots/logs that might carry real user or case data
+-->
+
+## Sanitizing before you post
+
+<!-- TODO: is there a tool, script, or checklist for scrubbing sensitive data before it lands in a public issue, PR, or Slack? -->
+
+## Who to ask
+
+<!-- TODO: if someone's unsure whether something is safe to post publicly, who do they check with? -->

--- a/day-one.md
+++ b/day-one.md
@@ -9,7 +9,7 @@ Every step below has a **pass condition**, so you always know whether you're act
 | [0](#0-fire-all-access-requests)      | Fire all access requests   | One batched message sent — then keep going while you wait                        |
 | [1](#1-confirm-your-accounts)         | Accounts confirmed         | GitHub org (2FA on), Slack, Google Workspace, password manager                   |
 | [2](#2-set-up-git)                    | Git setup                  | `ssh -T` greets your FLP user; git identity in your FLP directory is `@free.law` |
-| [3](#3-install-your-toolchain)        | Toolchain                  | Python, Node, and Docker resolve from your shell                                 |
+| [3](#3-install-your-toolchain)        | Toolchain                  | Python, Node, and Docker all answer from your shell                              |
 | [4](#4-wire-up-your-editor)           | Editor                     | Saving a `.py` file reformats it with ruff                                       |
 | [5](#5-set-up-claude-code)            | Claude Code                | `claude` starts authenticated; `/help` lists your FLP skills                     |
 | [6](#6-clone-your-repo-and-bootstrap) | Clone your repo, bootstrap | The test suite passes locally                                                    |
@@ -41,6 +41,8 @@ As each invite lands, sign in and finish setup:
 
 **Done when:** you can sign in to all four, and your GitHub account shows as a member of the FLP org with 2FA on.
 
+The other two requests from step 0 land later: your Claude Code seat gets used in step 5, and project credentials in step 6, when the repo's own setup docs tell you which ones it needs.
+
 ## 2. Set up git
 
 Work through [Git Setup](git-setup.md) — SSH keys, global config, and hooks. If you use GitHub for personal projects too, the host-alias section keeps the two accounts from stepping on each other.
@@ -55,19 +57,21 @@ That last check is worth doing deliberately. A hook that never fires looks ident
 
 ## 3. Install your toolchain
 
-Three things need to resolve from your shell. Use whichever manager you like — the goal is that versions come from each repo's pin files, so you never hand-pick a version per project.
+Three tools need to be installed and callable from your shell. Use whichever manager you like — the goal is that versions come from each repo's pin files, so you never hand-pick a version per project.
 
-- **Python** at the version your repo pins. Look for `.python-version` or `requires-python` in `pyproject.toml`. Repos with a `uv.lock` install fastest with [uv](https://docs.astral.sh/uv/); `pyenv` and `mise` read the same pin files.
+- **Python** through a version manager that reads pin files. Repos declare theirs in `.python-version` or `requires-python` in `pyproject.toml`. Repos with a `uv.lock` install fastest with [uv](https://docs.astral.sh/uv/); `pyenv` and `mise` read the same pin files.
 - **Node** resolved automatically on `cd`. FLP commonly uses [fnm](https://github.com/Schniz/fnm) (`eval "$(fnm env --use-on-cd)"` in your shell config); `nvm` and `mise` work the same way against `.node-version` or `.nvmrc`.
-- **Docker** running locally. Several projects — CourtListener especially — run their services in containers.
+- **Docker** running locally. Several projects — CourtListener especially — run their services in containers. Docker Desktop covers macOS and Windows; on Linux, start the daemon as a service and add yourself to the `docker` group so you can run it without `sudo`.
+
+These checks confirm the tools work — you're not matching any specific repo's version yet, since you clone in step 6.
 
 **Done when:**
 
-- `python --version` reports the version your repo pins
-- your Node manager switches versions when you `cd` into a directory with a `.node-version` or `.nvmrc` file
+- `python --version` answers from your shell (some systems reserve bare `python`, so `python3 --version` counts too — a version manager typically gives you both)
+- your Node manager switches versions on `cd` — make a scratch directory, drop a `.node-version` in it holding a version you don't currently have, and `cd` in
 - `docker run hello-world` prints its success message
 
-You'll confirm the Python and Node versions against your actual repo in step 6. Right now the point is having the tools installed and wired into your shell.
+Step 6 is where you confirm these versions against the repo you actually work in. Right now the point is having the tools installed and wired into your shell.
 
 ## 4. Wire up your editor
 

--- a/day-one.md
+++ b/day-one.md
@@ -139,5 +139,6 @@ You're up and running. From here:
 - Read [Culture](culture.md) — how we communicate, how decisions get made, urgency tiers, and flexing your day. It's day-two reading, and worth doing before your first week is out.
 - Skim your repo's `CLAUDE.md` and `CONTRIBUTING.md` if it has them. That's where team-specific conventions live.
 - Check the [HR section of the wiki](https://wiki.free.law/c/hr) for policies, benefits, and time off.
+- Take the [Foundations of Legal Research](https://elearning.aallnet.org/products/foundations-of-legal-research) course — ask your manager or onboarding buddy about access. Good to knock out sometime in your first week. Take time to actually sit with the material rather than speed-running it — it'll shape how you think about the data our tools work with.
 
 Anything on this page that didn't hold up for you is a bug in this page. Open an issue or a PR.

--- a/git-setup.md
+++ b/git-setup.md
@@ -1,14 +1,39 @@
 # Git Setup
 
-One-time setup for git on your machine. This covers SSH keys (especially important if you have a personal GitHub account alongside FLP), global git configuration, and shared hooks.
+One-time setup for git on your machine: SSH keys, global git configuration, and shared hooks. If you keep a separate GitHub account for FLP alongside a personal one, the SSH section shows how to wire both up side by side.
 
 Project-specific setup (pre-commit config, repo hooks, etc.) lives in each repo's own docs.
 
-## SSH Keys (Multi-Account Setup)
+## SSH Keys
 
-If you use GitHub for both personal projects and FLP, SSH keys with host aliases are the cleanest way to keep accounts separate. Each account gets its own key, and git automatically uses the right one based on the remote URL.
+### Which setup applies to you?
 
-This approach avoids the credential confusion that comes with HTTPS/PAT-based setups, where tokens for one account can interfere with the other.
+"Personal" and "FLP" here mean two separate **GitHub user accounts** — two distinct logins at github.com, each with its own username, SSH keys, and profile. That's different from having one account that commits under two email addresses.
+
+Most people have one GitHub account and join the `freelawproject` org with it. A second account is a personal preference — some folks like a hard wall between work and personal activity (separate contribution graphs, separate notifications, no chance of pushing from the wrong identity).
+
+Pick the row that matches you:
+
+| Your situation                                       | What you need                                                                                                              |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| One GitHub account (personal or work), joined to FLP | One SSH key, standard `github.com` remotes. Skip to [Global Gitconfig](#global-gitconfig) for per-directory commit emails. |
+| Two GitHub accounts — one personal, one for FLP      | Two SSH keys plus a host alias, so git picks the right account per repo. Continue below.                                   |
+
+Either way, the [Global Gitconfig](#global-gitconfig) section covers setting the right commit email per repo — that part applies to everyone.
+
+### Two-account setup
+
+With two accounts, SSH keys and a host alias are the cleanest split. Each account gets its own key, and git picks the right one from the remote URL:
+
+```bash
+# Personal account repo — uses your personal key
+git clone git@github.com:your-username/repo.git
+
+# FLP account repo — the `-flp` alias points git at your FLP key
+git clone git@github.com-flp:freelawproject/courtlistener.git
+```
+
+This is more reliable than HTTPS with personal access tokens, where a cached token for one account gets reused for the other.
 
 ### Generate two keys
 
@@ -138,11 +163,18 @@ For existing clones, update the remote:
 git remote set-url origin git@github.com-flp:freelawproject/courtlistener.git
 ```
 
-> **Single GitHub account?** If you only have one GitHub account, you can skip the host alias setup. Use a single key and the standard `github.com` host for everything.
+> With one GitHub account, a single key on the standard `github.com` host covers everything — no alias needed.
 
 ## Global Gitconfig
 
 ### Identity and conditional includes
+
+This applies whether you have one GitHub account or two. It's a separate layer from the SSH setup above:
+
+- **SSH keys and host aliases** decide which GitHub account pushes the commit.
+- **`user.email` and `includeIf`** decide which email is recorded inside the commit.
+
+With two accounts you'll want both. With one account, this section alone gets your FLP commits attributed correctly.
 
 Set your default (personal) identity in `~/.gitconfig`, then use `includeIf` to automatically switch to your FLP email for repos in your FLP directory:
 
@@ -156,6 +188,8 @@ Set your default (personal) identity in `~/.gitconfig`, then use `includeIf` to 
     path = ~/.gitconfig-flp
 ```
 
+The `gitdir:` path is wherever you keep your FLP clones — there's no required location, so set it to the directory you actually use and keep FLP repos together underneath it. The trailing slash matters: it makes the rule apply to everything inside that directory.
+
 ```gitconfig
 # ~/.gitconfig-flp
 [user]
@@ -163,6 +197,22 @@ Set your default (personal) identity in `~/.gitconfig`, then use `includeIf` to 
 ```
 
 This way, FLP repos get your FLP email and personal repos get your personal email, automatically. No need to remember `git config user.email` per repo.
+
+### Verify it works
+
+From inside a repo in your FLP directory:
+
+```bash
+git config user.email   # your @free.law address
+```
+
+And from a personal repo outside it:
+
+```bash
+git config user.email   # your personal address
+```
+
+If the FLP repo shows your personal email, the `gitdir:` path in `includeIf` doesn't match where that repo actually lives — `git rev-parse --show-toplevel` prints the path git sees, which is handy for comparing against the rule.
 
 ### Recommended settings
 


### PR DESCRIPTION
## Summary
- Rewrites day-one step 3 so its pass conditions are actually runnable when the reader hits them — they previously asked to verify "the version your repo pins" before the repo is cloned in step 6. Python/Node/Docker checks now confirm the tools work at all, with a scratch `.node-version` to exercise version-switching before any repo exists.
- Clarifies "personal vs FLP" in git-setup.md as two distinct GitHub *accounts* (not two commit emails on one account), adds a routing table so single-account readers skip straight to Global Gitconfig, and names the SSH-keys-vs-`includeIf` layering explicitly (SSH picks the account that pushes, `includeIf` picks the email in the commit) plus a verification step.

## Why
Both docs are meant to be followed top to bottom with checkable pass conditions. Step 3 asked for something unrunnable at that point in the flow — exactly the kind of gap a new hire would hit silently. The accounts/emails ambiguity is a similarly quiet failure mode: SSH working correctly says nothing about whether commits are attributed to the right email, so a new teammate could set this up wrong without any error surfacing until a reviewer (or `git blame`) catches it later.
